### PR TITLE
bumps Vault version to 0.9.3

### DIFF
--- a/helm/vaultlab-chart/templates/vault.yaml
+++ b/helm/vaultlab-chart/templates/vault.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: vault
-          image: vault:0.7.3
+          image: vault:0.9.3
           ports:
           - name: http
             containerPort: 8200


### PR DESCRIPTION
I debugged CI builds and saw builds failing due to cert-operator failures. 

```
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint.go:83","error":"health check failed","healthCheckDescription":"Ensure Vault API availability.","healthCheckMessage":"'\"\"' must be string in order to collect metrics for the Vault token expiration: execution failed","time":"2018-04-11 10:23:48.379"}
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint.go:83","error":"health check failed","healthCheckDescription":"Ensure Vault API availability.","healthCheckMessage":"'\"\"' must be string in order to collect metrics for the Vault token expiration: execution failed","time":"2018-04-11 10:23:52.948"}
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint.go:83","error":"health check failed","healthCheckDescription":"Ensure Vault API availability.","healthCheckMessage":"'\"\"' must be string in order to collect metrics for the Vault token expiration: execution failed","time":"2018-04-11 10:23:58.467"}
{"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint.go:83","error":"health check failed","healthCheckDescription":"Ensure Vault API availability.","healthCheckMessage":"'\"\"' must be string in order to collect metrics for the Vault token expiration: execution failed","time":"2018-04-11 10:24:02.852"}
```

AFAIK we fixed this in cert-operator somehow but the Vault version should also be bumped. 